### PR TITLE
Corrected Jan'alai's cooldown timer for Amani'shi Hatcher summonings and verified initial Fire Bomb timer

### DIFF
--- a/DBM-Party-Cataclysm/ZulAman/Janalai5.lua
+++ b/DBM-Party-Cataclysm/ZulAman/Janalai5.lua
@@ -26,13 +26,13 @@ local specWarnHatchAll		= mod:NewSpecialWarningSpell(43144, "Tank", nil, nil, 1,
 
 local timerBomb				= mod:NewCastTimer(12, 42630, nil, nil, nil, 3)
 local timerBombCD			= mod:NewNextTimer(30, 42630, nil, nil, nil, 3)
-local timerAdds				= mod:NewNextTimer(65, 43962, nil, nil, nil, 1, nil, DBM_CORE_L.TANK_ICON..DBM_CORE_L.DAMAGE_ICON)--I'm not evey sure it's timed or health based but it definitely wasn't 92 seconds in my run it was 65
+local timerAdds				= mod:NewNextTimer(60, 43962, nil, nil, nil, 1, nil, DBM_CORE_L.TANK_ICON..DBM_CORE_L.DAMAGE_ICON) -- this timer only works accurately when one of the hatchers has been killed. Otherwise it's getting delayed by 30 seconds each cycle.
 
 local berserkTimer			= mod:NewBerserkTimer(600)
 
 function mod:OnCombatStart(delay)
 	timerAdds:Start(12-delay)
-	timerBombCD:Start(55-delay)--Needs verification of consistency.
+	timerBombCD:Start(55-delay)
 	berserkTimer:Start(-delay)
 end
 


### PR DESCRIPTION
The Aman'shi Hatchers are a bit trick to track properly. To get the correct timers on them I went into the instance and made sure that the hatchers are down immediately. According to the comments in the lua file one guy was suposedly having a 90 seconds cooldown timer which basically confirms that the event is being delayed by 30 seconds as long as both hatchers are alive.

Additional video research has revealed that the hatchers may be summoned again when only one of the two hatchers has been killed as you can see in https://www.youtube.com/watch?v=KCL_VJaSDP4 that near the end of the fight, the boss summoned new hatchers while one was still alive.

Additionally I was so free to validate the initial cooldown timer for Fire Bomb (which actually is the timer for when he teleports to the center of the arena via spell 43098. The actual Fire Bomb cast happens 2,5s later but that's just nitpicking