### PR TITLE
Fix #20

### DIFF
--- a/DBM-Party-Legion/ReturnToKarazhan/OperaBeast.lua
+++ b/DBM-Party-Legion/ReturnToKarazhan/OperaBeast.lua
@@ -102,7 +102,7 @@ function mod:SPELL_AURA_APPLIED(args)
 			specWarnDrenched:Show(burningBlaze)
 		end
 	elseif spellId == 228221 then
-		timerSevereDustingCD:Start()
+		timerSevereDustingCD:Update(0, 12)
 		if args:IsPlayer() then
 			specWarnSevereDusting:Show()
 			specWarnSevereDusting:Play("justrun")


### PR DESCRIPTION
```
If Babblet reaches the targeted player, she will cast Severe Dusting (Damage), causing heavy damage and blinding the player for 4 seconds
Babblet will choose a new Severe Dusting (CD) target each time she casts Severe Dusting (Damage) on her target, or when the 12-second Severe Dusting (CD) channel expires
```

Since Babblet reaches the target, it causes the CD to start again. Change the `:Start` call to an `:Update` call to shut up this error.