### PR TITLE
fixed Lava Sweep timer

### DIFF
--- a/DBM-Party-WoD/IronDocks/GrimrailEnforcers.lua
+++ b/DBM-Party-WoD/IronDocks/GrimrailEnforcers.lua
@@ -47,6 +47,7 @@ local timerOgreTrapsCD			= mod:NewCDTimer(25, 163390, nil, nil, nil, 3)--25-30 v
 function mod:OnCombatStart(delay)
 	timerFlamingSlashCD:Start(5-delay)
 	timerOgreTrapsCD:Start(19.5-delay)
+	timerLavaSwipeCD:Start(15 - delay)
 end
 
 function mod:SPELL_CAST_START(args)


### PR DESCRIPTION
Currently, DBM does not show the timer for the 1st Lava Sweep cast. Experimentally was found the correct value to show timer when combat starts.