### PR TITLE
Update TheDreadPit.lua

### DIFF
--- a/DBM-Delves-WarWithin/TheDreadPit.lua
+++ b/DBM-Delves-WarWithin/TheDreadPit.lua
@@ -95,7 +95,7 @@ function mod:ENCOUNTER_START(eID)
 	if eID == 2989 then--Under-Lord Vik'tis
 		timerImpaleCD:Start(6.1)
 		timerBurrowingTremorsCD:Start(12.1)
-		timerStingingSwarmCD:Start(23.2)
+		timerStingingSwarmCD:Start(23)
 	elseif eID == 3120 then--Geargrave
 		DBM:AddMsg("Boss alerts/timers not yet implemented for Geargrave")
 	end


### PR DESCRIPTION
timer cd fix
Timer Жалящий рой(Timer448663cd-32.8) refreshed before expired. Remaining time is : 0.2