### PR TITLE
Update KriegvalsRest.lua

### DIFF
--- a/DBM-Delves-WarWithin/KriegvalsRest.lua
+++ b/DBM-Delves-WarWithin/KriegvalsRest.lua
@@ -38,7 +38,7 @@ function mod:SPELL_CAST_START(args)
 		timerFlamestormCD:Start()
 	elseif args.spellId == 449295 then
 		warnGroundSlam:Show()
-		timerGroundSlamCD:Start()
+		--timerGroundSlamCD:Start()
 	elseif args.spellId == 449339 then
 		specWarnRagingTantrum:Show()
 		specWarnRagingTantrum:Play("carefly")


### PR DESCRIPTION
DBM Debug: Timer Удар по земле(Timer449295cd-27.9) refreshed before expired. Remaining time is : 24.3 wrong timer
The 2nd cast happens 24.3 seconds earlier, it's possible it has a random sequence. I think it's worth disabling