### PR TITLE
Fix Blessing of Dusk being warned again if spellstolen

### DIFF
--- a/DBM-Delves-WarWithin/TrashCommon.lua
+++ b/DBM-Delves-WarWithin/TrashCommon.lua
@@ -674,7 +674,7 @@ function mod:SPELL_AURA_APPLIED(args)
 		else
 			warnEnrage:Show()
 		end
-	elseif args.spellId == 470592 or args.spellId == 443482 or args.spellId == 458879 then
+	elseif (args.spellId == 470592 or args.spellId == 443482 or args.spellId == 458879) and args:IsDestTypeHostile() then
 		specWarnBlessingofDuskDispel:Show(args.destName)
 		specWarnBlessingofDuskDispel:Play("dispelboss")
 	elseif args.spellId == 445407 then


### PR DESCRIPTION
Fixes an issue where Blessing of Dusk is warned of regardless of whether the buff recipient is friendly or hostile, causing [DBM to display a second dispel warning if it is spellstolen by a Mage](https://i.imgur.com/56XhkQR.png).